### PR TITLE
Updated reinstall_button.tsx

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/reinstall_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/reinstall_button.tsx
@@ -65,7 +65,7 @@ export function ReinstallButton(props: ReinstallationButtonProps) {
           content={
             <FormattedMessage
               id="xpack.fleet.integrations.installPackage.uploadedTooltip"
-              defaultMessage="This integration was installed by upload and cannot be automatically reinstalled. Please upload it again to reinstall."
+              defaultMessage="This is a custom integration and cannot be automatically reinstalled."
             />
           }
         >


### PR DESCRIPTION
## Summary

Fixes #230046

On hovering over the Reinstall Test Integration button, it previously displayed "This integration was installed by upload and cannot be automatically reinstalled. Please upload it again to reinstall" which was unclear to users.

Now the default message is updated to "This is a custom integration and cannot be automatically reinstalled.". No visual components changed,  only the default message was updated.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

